### PR TITLE
feat: provide babel options as an argument for vite plugin

### DIFF
--- a/packages/integration/src/babel.ts
+++ b/packages/integration/src/babel.ts
@@ -1,15 +1,25 @@
-import { transformFileAsync } from '@babel/core';
+import { TransformOptions, transformFileAsync } from '@babel/core';
 import {
   macaronBabelPlugin,
   PluginOptions,
   macaronStyledComponentsPlugin,
 } from '@macaron-css/babel';
 
-export async function babelTransform(path: string) {
+export type BabelOptions = Omit<TransformOptions, 'ast' | 'filename' | 'root' | 'sourceFileName' | 'sourceMaps' | 'inputSourceMap'>;
+
+export async function babelTransform(path: string, babel: BabelOptions = {}) {
   const options: PluginOptions = { result: ['', ''], path };
   const result = await transformFileAsync(path, {
-    plugins: [macaronStyledComponentsPlugin(), [macaronBabelPlugin(), options]],
-    presets: ['@babel/preset-typescript'],
+    ...babel,
+    plugins: [
+      ...(Array.isArray(babel.plugins) ? babel.plugins : []), 
+      macaronStyledComponentsPlugin(), 
+      [macaronBabelPlugin(), options]
+    ],
+    presets: [
+      ...(Array.isArray(babel.presets) ? babel.presets : []), 
+      '@babel/preset-typescript'
+    ],
     sourceMaps: false,
   });
 

--- a/packages/integration/src/index.ts
+++ b/packages/integration/src/index.ts
@@ -1,2 +1,2 @@
-export { babelTransform } from './babel';
+export { babelTransform, BabelOptions } from './babel';
 export { compile } from './compile';

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -11,13 +11,13 @@
     "directory": "packages/vite"
   },
   "dependencies": {
-    "@vanilla-extract/vite-plugin": "^3.1.6",
+    "@macaron-css/integration": "1.1.3",
     "@vanilla-extract/integration": "^6.0.0",
-    "@macaron-css/integration": "1.1.3"
+    "@vanilla-extract/vite-plugin": "^3.1.6"
   },
   "devDependencies": {
-    "vite": "^3.0.0",
-    "@vanilla-extract/recipes": "^0.2.5"
+    "@vanilla-extract/recipes": "^0.2.5",
+    "vite": "^3.0.0"
   },
   "files": [
     "dist",

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -1,12 +1,12 @@
-import { babelTransform, compile } from '@macaron-css/integration';
+import { babelTransform, compile, BabelOptions } from '@macaron-css/integration';
 import { processVanillaFile } from '@vanilla-extract/integration';
 import fs from 'fs';
 import { join, resolve } from 'path';
-import { normalizePath, Plugin, ResolvedConfig, ViteDevServer } from 'vite';
+import { normalizePath, PluginOption, ResolvedConfig, ViteDevServer } from 'vite';
 
 const extractedCssFileFilter = /extracted_(.*)\.css\.ts(\?used)?$/;
 
-export function macaronVitePlugin(): Plugin {
+export function macaronVitePlugin(options?: { babel?: BabelOptions }): PluginOption {
   let config: ResolvedConfig;
   let server: ViteDevServer;
   const cssMap = new Map<string, string>();
@@ -181,7 +181,7 @@ export function macaronVitePlugin(): Plugin {
         const {
           code,
           result: [file, cssExtract],
-        } = await babelTransform(id);
+        } = await babelTransform(id, options?.babel);
 
         if (!cssExtract || !file) return null;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2129,6 +2129,13 @@
     media-query-parser "^2.0.2"
     outdent "^0.8.0"
 
+"@vanilla-extract/dynamic@^2.0.3":
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/@vanilla-extract/dynamic/-/dynamic-2.0.3.tgz#44b4e018cbdfb6af3d27e73c78b38617dfe419ad"
+  integrity sha512-Rglfw2gXAYiBzAQ4jgUG7rBgE2c88e/zcG27ZVoIqMHVq56wf2C1katGMm1yFMNBgzqM7oBNYzz4YOMzznydkg==
+  dependencies:
+    "@vanilla-extract/private" "^1.0.3"
+
 "@vanilla-extract/esbuild-plugin@^2.0.5":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@vanilla-extract/esbuild-plugin/-/esbuild-plugin-2.2.1.tgz#bb3800843765d603f40d15507bfe4c7c6aca9392"


### PR DESCRIPTION
Solves #38 

Copies the signature from the React Vite plugin, which allows Vite users to extend the babel configuration that Macaron uses under the hood.

Example:

```
macaronVitePlugin({
  babel: {
    plugins: [
      ['@babel/plugin-proposal-decorators', { legacy: true }],
      ['@babel/plugin-proposal-class-properties', { loose: false }],
    ],
  },
}),
```