### PR TITLE
docs: fix vanilla api examples

### DIFF
--- a/site/src/pages/docs/dynamic-styling.page.mdx
+++ b/site/src/pages/docs/dynamic-styling.page.mdx
@@ -53,10 +53,11 @@ const colorVar = createVar();
 function MyButton(props) {
   return (
     <button
-      className={style({ color: colorVar, border: 'none' })}
-      style={{
-        [colorVar]: props.color,
-      }}
+      class={style({
+        vars: { [colorVar]: props.color },
+        color: colorVar,
+        border: 'none'
+      })}
     >
       Click me
     </button>


### PR DESCRIPTION
```
style={{
  ['--cssVariableName']: 'red', // correct
  ['var(--cssVariableName)']: 'red', // wrong
}}
```

Because the variable named `colorVar` has the value `var(--cssVariableName)`, css variable was not added as in the example.

To use colorVar directly in the inline style prop, delete 'var(',')' from the colorVar string, or use it like this commit.