### PR TITLE
feat(esbuild): add includeNodeModules option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -57,8 +57,8 @@
       "name": "macaron-react-example",
       "version": "0.0.0",
       "dependencies": {
-        "@macaron-css/core": "1.5.2",
-        "@macaron-css/react": "1.5.3",
+        "@macaron-css/core": "1.5.1",
+        "@macaron-css/react": "1.5.1",
         "@macaron-css/vite": "1.5.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
@@ -255,9 +255,9 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@macaron-css/core": "1.5.2",
+        "@macaron-css/core": "1.5.1",
         "@macaron-css/esbuild": "1.5.1",
-        "@macaron-css/solid": "1.5.3",
+        "@macaron-css/solid": "1.5.1",
         "babel-preset-solid": "^1.4.2",
         "esbuild": "^0.14.42",
         "solid-js": "^1.4.3"
@@ -267,8 +267,8 @@
       "name": "macaron-solid-start-example",
       "version": "0.1.0",
       "dependencies": {
-        "@macaron-css/core": "1.5.2",
-        "@macaron-css/solid": "1.5.3",
+        "@macaron-css/core": "1.5.1",
+        "@macaron-css/solid": "1.5.1",
         "@solidjs/meta": "^0.28.0",
         "@solidjs/router": "^0.5.0",
         "solid-js": "^1.6.0",
@@ -2148,7 +2148,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@macaron-css/core": "1.5.2",
+        "@macaron-css/core": "1.5.1",
         "@macaron-css/esbuild": "1.5.1",
         "esbuild": "^0.14.42"
       }
@@ -2157,7 +2157,7 @@
       "name": "macaron-vite-example",
       "version": "0.0.0",
       "dependencies": {
-        "@macaron-css/core": "1.5.2",
+        "@macaron-css/core": "1.5.1",
         "@macaron-css/vite": "1.5.1"
       },
       "devDependencies": {
@@ -17601,7 +17601,7 @@
     },
     "packages/core": {
       "name": "@macaron-css/core",
-      "version": "1.5.2",
+      "version": "1.5.1",
       "license": "MIT",
       "dependencies": {
         "@vanilla-extract/css": "^1.7.1",
@@ -17669,11 +17669,8 @@
     },
     "packages/qwik": {
       "name": "@macaron-css/qwik",
-      "version": "1.5.3",
+      "version": "1.5.1",
       "license": "MIT",
-      "dependencies": {
-        "@macaron-css/core": "1.5.2"
-      },
       "devDependencies": {
         "@builder.io/qwik": "^1.1.5",
         "@vanilla-extract/recipes": "^0.2.5"
@@ -17685,10 +17682,10 @@
     },
     "packages/react": {
       "name": "@macaron-css/react",
-      "version": "1.5.3",
+      "version": "1.5.1",
       "license": "MIT",
       "dependencies": {
-        "@macaron-css/core": "1.5.2"
+        "@macaron-css/core": "1.5.1"
       },
       "devDependencies": {
         "@types/react": "^18.0.12",
@@ -17705,10 +17702,10 @@
     },
     "packages/solid": {
       "name": "@macaron-css/solid",
-      "version": "1.5.3",
+      "version": "1.5.1",
       "license": "MIT",
       "dependencies": {
-        "@macaron-css/core": "1.5.2"
+        "@macaron-css/core": "1.5.1"
       },
       "devDependencies": {
         "@vanilla-extract/recipes": "^0.2.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,8 +57,8 @@
       "name": "macaron-react-example",
       "version": "0.0.0",
       "dependencies": {
-        "@macaron-css/core": "1.5.1",
-        "@macaron-css/react": "1.5.1",
+        "@macaron-css/core": "1.5.2",
+        "@macaron-css/react": "1.5.3",
         "@macaron-css/vite": "1.5.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
@@ -255,9 +255,9 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@macaron-css/core": "1.5.1",
+        "@macaron-css/core": "1.5.2",
         "@macaron-css/esbuild": "1.5.1",
-        "@macaron-css/solid": "1.5.1",
+        "@macaron-css/solid": "1.5.3",
         "babel-preset-solid": "^1.4.2",
         "esbuild": "^0.14.42",
         "solid-js": "^1.4.3"
@@ -267,8 +267,8 @@
       "name": "macaron-solid-start-example",
       "version": "0.1.0",
       "dependencies": {
-        "@macaron-css/core": "1.5.1",
-        "@macaron-css/solid": "1.5.1",
+        "@macaron-css/core": "1.5.2",
+        "@macaron-css/solid": "1.5.3",
         "@solidjs/meta": "^0.28.0",
         "@solidjs/router": "^0.5.0",
         "solid-js": "^1.6.0",
@@ -2148,7 +2148,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@macaron-css/core": "1.5.1",
+        "@macaron-css/core": "1.5.2",
         "@macaron-css/esbuild": "1.5.1",
         "esbuild": "^0.14.42"
       }
@@ -2157,7 +2157,7 @@
       "name": "macaron-vite-example",
       "version": "0.0.0",
       "dependencies": {
-        "@macaron-css/core": "1.5.1",
+        "@macaron-css/core": "1.5.2",
         "@macaron-css/vite": "1.5.1"
       },
       "devDependencies": {
@@ -17601,7 +17601,7 @@
     },
     "packages/core": {
       "name": "@macaron-css/core",
-      "version": "1.5.1",
+      "version": "1.5.2",
       "license": "MIT",
       "dependencies": {
         "@vanilla-extract/css": "^1.7.1",
@@ -17669,8 +17669,11 @@
     },
     "packages/qwik": {
       "name": "@macaron-css/qwik",
-      "version": "1.5.1",
+      "version": "1.5.3",
       "license": "MIT",
+      "dependencies": {
+        "@macaron-css/core": "1.5.2"
+      },
       "devDependencies": {
         "@builder.io/qwik": "^1.1.5",
         "@vanilla-extract/recipes": "^0.2.5"
@@ -17682,10 +17685,10 @@
     },
     "packages/react": {
       "name": "@macaron-css/react",
-      "version": "1.5.1",
+      "version": "1.5.3",
       "license": "MIT",
       "dependencies": {
-        "@macaron-css/core": "1.5.1"
+        "@macaron-css/core": "1.5.2"
       },
       "devDependencies": {
         "@types/react": "^18.0.12",
@@ -17702,10 +17705,10 @@
     },
     "packages/solid": {
       "name": "@macaron-css/solid",
-      "version": "1.5.1",
+      "version": "1.5.3",
       "license": "MIT",
       "dependencies": {
-        "@macaron-css/core": "1.5.1"
+        "@macaron-css/core": "1.5.2"
       },
       "devDependencies": {
         "@vanilla-extract/recipes": "^0.2.5",

--- a/packages/esbuild/src/index.ts
+++ b/packages/esbuild/src/index.ts
@@ -14,9 +14,14 @@ import { babelTransform, compile } from '@macaron-css/integration';
     -> process the file with vanilla-extract
     -> resolve with js loader
 */
+
+interface MacaronEsbuildPluginOptions {
+  includeNodeModulesPattern?: RegExp;
+}
+
 export function macaronEsbuildPlugin({
-  includeNodeModules = false,
-} = {}): EsbuildPlugin {
+  includeNodeModulesPattern,
+}: MacaronEsbuildPluginOptions = {}): EsbuildPlugin {
   return {
     name: 'macaron-css-esbuild',
     setup(build) {
@@ -92,7 +97,11 @@ export function macaronEsbuildPlugin({
       );
 
       build.onLoad({ filter: /\.(j|t)sx?$/ }, async args => {
-        if (!includeNodeModules && args.path.includes('node_modules')) return;
+        if (args.path.includes('node_modules')) {
+          if(includeNodeModulesPattern && !includeNodeModulesPattern.test(args.path)) {
+            return;
+          }
+        };
 
         // gets handled by @vanilla-extract/esbuild-plugin
         if (args.path.endsWith('.css.ts')) return;

--- a/packages/esbuild/src/index.ts
+++ b/packages/esbuild/src/index.ts
@@ -98,9 +98,8 @@ export function macaronEsbuildPlugin({
 
       build.onLoad({ filter: /\.(j|t)sx?$/ }, async args => {
         if (args.path.includes('node_modules')) {
-          if(includeNodeModulesPattern && !includeNodeModulesPattern.test(args.path)) {
-            return;
-          }
+          if(!includeNodeModulesPattern) return;
+          if(!includeNodeModulesPattern.test(args.path)) return;
         };
 
         // gets handled by @vanilla-extract/esbuild-plugin

--- a/packages/esbuild/src/index.ts
+++ b/packages/esbuild/src/index.ts
@@ -4,7 +4,7 @@ import { dirname, join } from 'path';
 import { babelTransform, compile } from '@macaron-css/integration';
 
 /*
-  -> load /(t|j)sx?/ 
+  -> load /(t|j)sx?/
   -> extract css and inject imports (extracted_HASH.css.ts)
     -> resolve all imports
     -> load imports, bundle code again
@@ -14,7 +14,9 @@ import { babelTransform, compile } from '@macaron-css/integration';
     -> process the file with vanilla-extract
     -> resolve with js loader
 */
-export function macaronEsbuildPlugin(): EsbuildPlugin {
+export function macaronEsbuildPlugin({
+  includeNodeModules = false,
+} = {}): EsbuildPlugin {
   return {
     name: 'macaron-css-esbuild',
     setup(build) {
@@ -90,7 +92,7 @@ export function macaronEsbuildPlugin(): EsbuildPlugin {
       );
 
       build.onLoad({ filter: /\.(j|t)sx?$/ }, async args => {
-        if (args.path.includes('node_modules')) return;
+        if (!includeNodeModules && args.path.includes('node_modules')) return;
 
         // gets handled by @vanilla-extract/esbuild-plugin
         if (args.path.endsWith('.css.ts')) return;


### PR DESCRIPTION
Add `includeNodeModules` option to esbuild plugin.

- Allows including styles from packages in node_modules
- Defaults to `false` for backward compatibility

Closes #67.