### PR TITLE
Fix(esbuild): add options to plugins wrapper

### DIFF
--- a/packages/esbuild/src/index.ts
+++ b/packages/esbuild/src/index.ts
@@ -128,7 +128,7 @@ export function macaronEsbuildPlugin({
   };
 }
 
-export const macaronEsbuildPlugins = () => [
-  macaronEsbuildPlugin(),
+export const macaronEsbuildPlugins = (options: MacaronEsbuildPluginOptions = {}) => [
+  macaronEsbuildPlugin(options),
   require('@vanilla-extract/esbuild-plugin').vanillaExtractPlugin(),
 ];


### PR DESCRIPTION
Follow up to https://github.com/macaron-css/macaron/pull/68. Overlooked the crucial moment.

We need to provide options to plugins wrapper `macaronEsbuildPlugins`, not only plugin `macaronEsbuildPlugin` alone. Because macaron also needs to load vanilla-extract plugin by default. So one can use in esbuild config:
```ts
{
  plugins: [
    ...macaronEsbuildPlugins({
      includeNodeModulesPattern: /.../
    }),
  }
}
```

For now workaround is:
```ts
const macaronPlugins = () => ([
  macaronEsbuildPlugin({
    includeNodeModulesPattern: /\.tsx?$/,
  }),
  macaronEsbuildPlugins().at(-1), // vanilla-extract
]);
```