### PR TITLE
fix: emit source maps in esbuild

### DIFF
--- a/packages/esbuild/src/index.ts
+++ b/packages/esbuild/src/index.ts
@@ -108,7 +108,9 @@ export function macaronEsbuildPlugin({
         const {
           code,
           result: [file, cssExtract],
-        } = await babelTransform(args.path);
+        } = await babelTransform(args.path, {
+          sourceMaps: build.initialOptions.sourcemap ? "inline" : false,
+        });
 
         // the extracted code and original are the same -> no css extracted
         if (file && cssExtract && cssExtract !== code) {

--- a/packages/integration/src/babel.ts
+++ b/packages/integration/src/babel.ts
@@ -5,7 +5,7 @@ import {
   macaronStyledComponentsPlugin,
 } from '@macaron-css/babel';
 
-export type BabelOptions = Omit<TransformOptions, 'ast' | 'filename' | 'root' | 'sourceFileName' | 'sourceMaps' | 'inputSourceMap'>;
+export type BabelOptions = Omit<TransformOptions, 'ast' | 'filename' | 'root' | 'sourceFileName' | 'inputSourceMap'>;
 
 export async function babelTransform(path: string, babel: BabelOptions = {}) {
   const options: PluginOptions = { result: ['', ''], path };
@@ -20,7 +20,6 @@ export async function babelTransform(path: string, babel: BabelOptions = {}) {
       ...(Array.isArray(babel.presets) ? babel.presets : []), 
       '@babel/preset-typescript'
     ],
-    sourceMaps: false,
   });
 
   if (result === null || result.code === null)


### PR DESCRIPTION
This change makes the esbuild plugin emit source maps inline (if enabled). esbuild can recognize inline source maps and uses them for the rest of the build.

`build.initialOptions.sourcemap` can have various values (boolean, undefined, a few string values). A simple truthy check is what we want, since `false` and `undefined` disable source maps, and all other values enable them. Whatever value is given to esbuild, we only want to output an inline source map since esbuild will post-process it anyway.